### PR TITLE
Docker

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,5 +4,4 @@ DIRNAME=`dirname "$0"`
 
 cd $DIRNAME
 
-docker-compose build
-# docker-compose build --no-cache
+docker build -t vmtautoupdater .

--- a/build.sh
+++ b/build.sh
@@ -4,4 +4,5 @@ DIRNAME=`dirname "$0"`
 
 cd $DIRNAME
 
-docker-compose build --no-cache
+docker-compose build
+# docker-compose build --no-cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,0 @@
-version: "3"
-services:
-  vmt-autoupdater:
-    build:
-      context: .
-      dockerfile: ./Dockerfile
-    # volumes:
-    #   - ./src:/usr/src

--- a/run.sh
+++ b/run.sh
@@ -3,4 +3,6 @@ DIRNAME=`dirname "$0"`
 
 cd $DIRNAME
 
-docker-compose run --rm vmt-autoupdater
+docker-compose run vmt-autoupdater
+
+# docker-compose run --rm vmt-autoupdater

--- a/run.sh
+++ b/run.sh
@@ -3,6 +3,4 @@ DIRNAME=`dirname "$0"`
 
 cd $DIRNAME
 
-docker-compose run vmt-autoupdater
-
-# docker-compose run --rm vmt-autoupdater
+docker run -d vmt-autoupdater

--- a/vmt_autoupdate.py
+++ b/vmt_autoupdate.py
@@ -1,4 +1,5 @@
 import time
+from traceback import print_list
 import Config as config
 from AVAXAPI import AvalancheAPI
 
@@ -16,6 +17,9 @@ print(f'We have {dolla/(10**decimals)} {symbol}')
 print(f'We have {cdolla/(10**decimals)} claimable {symbol}')
 
 minReqDolla = 0
+
+def get_reqDollaForNxtLvl(token):
+    return int(token.get('reqDollaForNxtLvl'))
 
 while True:
     dolla = avapi.get_token_holdings(config.DOLLA_CONTRACT_ADRESS)
@@ -83,6 +87,8 @@ while True:
             "reqDollaForNxtLvl" : forNxtLvl*(10**decimals)
         }
         myTycoons.append(tycoon)
+
+    myTycoons.sort(key=get_reqDollaForNxtLvl)
 
     for tycoon in myTycoons:
         print("Processing Tycoon #" + str(tycoon['tid']))


### PR DESCRIPTION
- Got rid of docker-compose dependency, was not really necessary
- Update run.sh script to run the container in detached mode, this way it's not tied to the terminal it's run in. You can use `docker logs -f <image id>` to follow the container's console output
- Added sorting by "reqDollaForNxtLvl" so lower-level tycoons are upgraded first, since those are the most efficient upgrades.